### PR TITLE
Use a more recent build of python-rocksdb as a dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-python-rocksdb = "^0.7.0"
+faust-streaming-rocksdb = "^0.8.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"


### PR DESCRIPTION
`python-rocksdb` hasn't been maintained in years, I've recently deployed a wheel for `0.9.0` onto PyPi. Any interest in using this?